### PR TITLE
Metabase client authentication

### DIFF
--- a/R/metabase_client.R
+++ b/R/metabase_client.R
@@ -18,15 +18,15 @@ metabase_auth <- function() {
   )
   api_url <- Sys.getenv("METABASE_API_URL")
   creds_json <- jsonlite::toJSON(creds, auto_unbox = TRUE)
-  req <- httr::POST(paste0(api_url, "/api/session"),
+  resp <- httr::POST(paste0(api_url, "/api/session"),
                     httr::add_headers(
                       "Content-Type" = "application/json"
                     ),
                     body = creds_json
   )
 
-  if (req$status_code >= 200 && req$status_code < 300) {
-    json_auth_response <- httr::content(req, "text")
+  if (resp$status_code >= 200 && resp$status_code < 300) {
+    json_auth_response <- httr::content(resp, "text")
     mb_session_token <- toString(jsonlite::fromJSON(json_auth_response))
 
     # make sure session is legit
@@ -37,7 +37,7 @@ metabase_auth <- function() {
     print("Session is authenticated")
     return(mb_session)
   } else {
-    print(req$status_code("Session is not authenticated and the error code is: ", req$status_code))
+    print(paste0("Session is not authenticated and the error code is: ", resp$status_code))
     return(NULL)
   }
 }


### PR DESCRIPTION
 Authenticate to Metabase

 Initialize an authenticated session with Metabase.

(Maybe)
 @param base_url The base URL of your Metabase server
 @param username The username to log in as

 @return Metabaser session

 @examples
 mb_session <- metabase_auth()